### PR TITLE
Fix ServerSync replication behavior.

### DIFF
--- a/src/sync/server.luau
+++ b/src/sync/server.luau
@@ -86,7 +86,7 @@ local function server(options: ServerOptions): ServerSyncer
 			end
 
 			local diffs = patch.diff(stateSnapshot, state)
-			stateSnapshot = state
+			stateSnapshot = table.clone(state)
 			changed = false
 
 			for _, player in Players:GetPlayers() do


### PR DESCRIPTION
# The problem I have

I have a list of modules that contain their relative atom and data model.
Then I export a const named "sharedAtoms" containing all of these atoms.
It looks similar to this:
```ts
export const sharedAtoms = {
    infoMapAtom: InfoMapAtomModule.infoMapAtom,
}
```
where InfoMapAtomModule looks similar to this:
```ts
export namespace InfoMapAtomModule {
    export type InfoMap = {
        [userId in string]?: SomeNestedObject,
    }
    export const infoMapAtom = atom<InfoMap>({}),
}
```

The problem I have is that whenever the server modifies this data, it replicates the empty payload to the clients.

# The stuff in the current codebase that causes my problem

After the initial replication of the payload to the client, the "stateSnapshot" variable is assigned to the "state" variable, so further changes to the "state" variable modify both of these tables, resulting in further changes never being replicated.

# Proposed changes
We should clone the "state" variable before assigning it to the "stateSnapshot" variable. By cloning the "state" variable before assigning it to the "stateSnapshot" variable, further indice changes to the "state" variable no longer appear in the "stateSnapshot" variable.
There may also be a reason to deep clone the "state" variable instead of shallow copy, although I'm not sure about it because shallow copy solved the problem for me.