### PR TITLE
fix: handle sparse array patches

### DIFF
--- a/src/__tests__/sync/client.spec.luau
+++ b/src/__tests__/sync/client.spec.luau
@@ -28,4 +28,20 @@ return function()
 		expect(a().b).to.equal(3)
 		expect(a().c).to.equal(2)
 	end)
+
+	it("fixes sparse array patches", function()
+		local a = atom({ 1 })
+		local client = sync.client({ atoms = { a = a } })
+
+		-- This patch would be the result of a diff between { 1 } and { 1, 2 } that
+		-- was JSON-serialized and deserialized. The client should be able to catch
+		-- this and convert the string key back to a number.
+		client:sync({
+			type = "patch",
+			data = { a = { ["2"] = 2 } },
+		})
+
+		expect(a()["2" :: any]).to.never.be.ok()
+		expect(a()[2]).to.equal(2)
+	end)
 end

--- a/src/sync/patch.luau
+++ b/src/sync/patch.luau
@@ -44,8 +44,16 @@ local function apply(state: any, patches: any): any
 	end
 
 	local nextState = table.clone(state)
+	local stateIsArray = state[1] ~= nil
 
 	for key, patch in patches do
+		-- Diff-checking an array produces a sparse array, which will not be
+		-- preserved when converted to JSON. To prevent this, we turn string
+		-- keys back into numeric keys.
+		if stateIsArray and type(key) == "string" then
+			key = tonumber(key) or key
+		end
+
 		nextState[key] = apply(nextState[key], patch)
 	end
 


### PR DESCRIPTION
When an element is added to an array, diff checking will return a sparse array (i.e. `[1] → [1, 2]` produces `{ [2] = 2 }`). This sparse array's numeric indices will converted to string keys when sent over a remote event, causing hard-to-trace bugs.

This PR adds special behavior to `patch.apply` when the previous state is an array. Converting string keys to numeric indices in this case should be a non-invasive fix.