### PR TITLE
fix: remove type union in observe

### DIFF
--- a/src/observe.luau
+++ b/src/observe.luau
@@ -44,7 +44,4 @@ local function observe<K, V>(molecule: Molecule<{ [K]: V }>, factory: (value: V,
 	return cleanup
 end
 
-return observe :: <K, V>(
-	molecule: Molecule<{ [K]: V }>,
-	factory: ((value: V, key: K) -> () -> ()) | (value: V, key: K) -> ()
-) -> () -> ()
+return observe


### PR DESCRIPTION
Fixes type inference and autocomplete when using observe. This change requires explicitly typing the function's return as () when the function doesn't return a disconnect callback, as shown in the example.

Previously, Luau would display ": a" for both 'value' and 'key' on hover, and autocomplete would not work.

```luau
charm.observe(atom, function(value, key): ()
    print(value, key)
end)