### PR TITLE
docs: rewrite documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,12 +218,12 @@ Call `observe` to create an instance of `factory` for each key present in a dict
 > Because `observe` tracks the lifetime of each key in your data, your keys must be unique and unchanging. If your data is not keyed by unique and stable identifiers, consider using [`mapped`](#mappedcallback-mapper) to transform it into a keyed object before passing it to `observe`.
 
 ```luau
-local todosAtom: Atom<{ [string]: string }> = atom({})
+local todosAtom: Atom<{ [string]: Todo }> = atom({})
 
 observe(todosAtom, function(todo, key)
-	print(`Added {todo}`)
+	print(`Added {key}: {todo.name}`)
 	return function()
-		print(`Removed {todo}`)
+		print(`Removed {key}`)
 	end
 end)
 ```
@@ -343,10 +343,10 @@ Call `useAtom` at the top-level of a React component to read from an atom or sel
 ```luau
 local todosAtom = require(script.Parent.todosAtom)
 
-local function Todos() {
+local function Todos()
 	local todos = useAtom(todosAtom)
 	-- ...
-}
+end
 ```
 
 If your selector depends on the component's state or props, remember to pass them in a dependency array. This prevents skipped updates when an untracked parameter of the selector changes.

--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ end) --> 4
 ### React component
 
 ```luau
-local counter = require(script.Parent.counterAtom)
+local counter = require(script.Parent.counter)
 local counterAtom = counter.counterAtom
 local incrementCounter = counter.incrementCounter
 
@@ -593,7 +593,7 @@ end
 ### Vide component
 
 ```luau
-local counter = require(script.Parent.counterAtom)
+local counter = require(script.Parent.counter)
 local counterAtom = counter.counterAtom
 local incrementCounter = counter.incrementCounter
 
@@ -617,8 +617,8 @@ Charm is designed for both client and server use, but there are often cases wher
 Start by creating a set of atoms to sync between the server and clients. Export these atoms from a module to be shared between the server and client:
 
 ```luau
-local counter = require(script.Parent.counterAtom)
-local todos = require(script.Parent.todosAtom)
+local counter = require(script.Parent.counter)
+local todos = require(script.Parent.todos)
 
 return {
 	counterAtom = counter.counterAtom,

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 **Charm** is an atomic state management library inspired by [Jotai](https://jotai.org) and [Nanostores](https://github.com/nanostores/nanostores). Store your immutable state in atoms, and write intuitive functions that read, write, and subscribe to state.
 
+See an example of Charm's features in [this example repository](https://github.com/littensy/charm-example).
+
 ## 🍀 Features
 
 - ⚛️ **Manage state with _atoms_.** Decompose state into tiny, composable containers called _atoms_, as opposed to combining them into a single store.
@@ -617,6 +619,7 @@ Charm is designed for both client and server use, but there are often cases wher
 Start by creating a set of atoms to sync between the server and clients. Export these atoms from a module to be shared between the server and client:
 
 ```luau
+-- atoms.luau
 local counter = require(script.Parent.counter)
 local todos = require(script.Parent.todos)
 
@@ -632,6 +635,7 @@ Then, on the server, create a server sync object and pass in the atoms to sync. 
 > If `preserveHistory` is `true`, the server will send multiple payloads to the client, so the callback passed to `connect` should accept a variadic `...payloads` parameter. Otherwise, you only need to handle a single `payload` parameter.
 
 ```luau
+-- sync.server.luau
 local atoms = require(script.Parent.atoms)
 
 local syncer = CharmSync.server({ atoms = atoms })
@@ -652,6 +656,7 @@ end)
 Finally, on the client, create a client sync object and use it to apply incoming state changes.
 
 ```luau
+-- sync.client.luau
 local atoms = require(script.Parent.atoms)
 
 local syncer = CharmSync.client({ atoms = atoms })

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 </div>
 
-**Charm** is an atomic state management library inspired by [Jotai](https://jotai.org) and [Nanostores](https://github.com/nanostores/nanostores). Store your immutable state in _atoms_, and write intuitive functions that read, write, and subscribe to state.
+**Charm** is an atomic state management library inspired by [Jotai](https://jotai.org) and [Nanostores](https://github.com/nanostores/nanostores). Store your immutable state in atoms, and write intuitive functions that read, write, and subscribe to state.
 
 ## 🍀 Features
 

--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@
 
 </div>
 
-**Charm** is an atomic state management library inspired by [Jotai](https://jotai.org) and [Nanostores](https://github.com/nanostores/nanostores). Designed to be a more composable alternative to Reflex, Charm aims to address common criticisms of Rodux-like state containers to better address certain use cases.
+**Charm** is an atomic state management library inspired by [Jotai](https://jotai.org) and [Nanostores](https://github.com/nanostores/nanostores). Store your immutable state in _atoms_, and write intuitive functions that read, write, and subscribe to state.
 
 ## 🍀 Features
 
-- ⚛️ **Manage state with _atoms_.** Decompose state into small, distinct containers called _atoms_, as opposed to combining them into a single store.
+- ⚛️ **Manage state with _atoms_.** Decompose state into tiny, composable containers called _atoms_, as opposed to combining them into a single store.
 
 - 💪 **Minimal, yet powerful.** Less boilerplate — write simple functions to read from and write to state.
 
 - 🔬 **Immediate updates.** Listeners run asynchronously by default, avoiding the cascading effects of deferred updates and improving responsiveness.
 
-- 🦄 **Like magic.** Selector functions can be subscribed to as-is — their memoization and dependencies are resolved for you.
+- 🦄 **Like magic.** Selector functions can be subscribed to as-is — with implicit dependency tracking, atoms are captured and memoized for you.
 
 ---
 

--- a/src/charm/src/computed.luau
+++ b/src/charm/src/computed.luau
@@ -1,21 +1,20 @@
 local atom = require(script.Parent.atom)
 local store = require(script.Parent.store)
 local types = require(script.Parent.types)
-type Atom<T> = types.Atom<T>
 type AtomOptions<T> = types.AtomOptions<T>
-type Molecule<T> = types.Molecule<T>
+type Selector<T> = types.Selector<T>
 
 --[=[
 	Creates a read-only atom that derives its state from one or more atoms.
 	Used to avoid unnecessary recomputations if multiple listeners depend on
-	the same molecule.
-	
-	@param molecule The function that produces the state.
+	the same atoms.
+
+	@param callback The function that produces the state.
 	@param options Optional configuration.
 	@return A new read-only atom.
 ]=]
-local function computed<T>(molecule: Molecule<T>, options: AtomOptions<T>?): Molecule<T>
-	local dependencies, state = store.capture(molecule)
+local function computed<T>(callback: Selector<T>, options: AtomOptions<T>?): Selector<T>
+	local dependencies, state = store.capture(callback)
 	local computedAtom = atom(state, options)
 	local computedRef = setmetatable({ current = computedAtom }, { __mode = "v" })
 
@@ -24,7 +23,7 @@ local function computed<T>(molecule: Molecule<T>, options: AtomOptions<T>?): Mol
 
 		if computedAtom then
 			store.disconnect(dependencies, listener)
-			dependencies, state = store.capture(molecule)
+			dependencies, state = store.capture(callback)
 			store.connect(dependencies, listener, computedAtom)
 			computedAtom(state)
 		end

--- a/src/charm/src/effect.luau
+++ b/src/charm/src/effect.luau
@@ -9,7 +9,7 @@ type Cleanup = () -> ()
 	@param callback The function to run.
 	@return A function that unsubscribes the callback.
 ]=]
-local function effect(callback: () -> (() -> ())?): () -> ()
+local function effect(callback: () -> Cleanup?): Cleanup
 	local dependencies, cleanup = store.capture(callback)
 	local disconnected = false
 

--- a/src/charm/src/index.d.ts
+++ b/src/charm/src/index.d.ts
@@ -38,6 +38,14 @@ declare namespace Charm {
 	type Selector<State> = () => State;
 
 	/**
+	 * A function that depends on one or more atoms and produces a value. Can be
+	 * used to derive state from atoms.
+	 *
+	 * @returns The current state.
+	 */
+	type Molecule<State> = Selector<State>;
+
+	/**
 	 * Infers the type of the state produced by the given function.
 	 */
 	type StateOf<T> = T extends Selector<infer State> ? State : never;

--- a/src/charm/src/index.d.ts
+++ b/src/charm/src/index.d.ts
@@ -17,7 +17,7 @@ declare namespace Charm {
 	 * @param state The next state or a function that produces the next state.
 	 * @returns The current state, if no arguments are provided.
 	 */
-	interface Atom<State> extends Molecule<State> {
+	interface Atom<State> extends Selector<State> {
 		/**
 		 * @deprecated This property is not meant to be accessed directly.
 		 */
@@ -26,21 +26,21 @@ declare namespace Charm {
 		 * @param state The next state or a function that produces the next state.
 		 * @returns The current state, if no arguments are provided.
 		 */
-		(state: State | ((prev: State) => State)): void;
+		(state?: State | ((prev: State) => State)): State;
 	}
 
 	/**
-	 * A function that depends on one or more atoms and produces a state. Can be
+	 * A function that depends on one or more atoms and produces a value. Can be
 	 * used to derive state from atoms.
 	 *
 	 * @returns The current state.
 	 */
-	type Molecule<State> = () => State;
+	type Selector<State> = () => State;
 
 	/**
-	 * Infers the type of the state produced by the given molecule.
+	 * Infers the type of the state produced by the given function.
 	 */
-	type StateOf<T> = T extends Molecule<infer State> ? State : never;
+	type StateOf<T> = T extends Selector<infer State> ? State : never;
 
 	interface AtomOptions<State> {
 		/**
@@ -66,24 +66,24 @@ declare namespace Charm {
 	/**
 	 * Creates a read-only atom that derives its state from one or more atoms.
 	 * Used to avoid unnecessary recomputations if multiple listeners depend on
-	 * the same molecule.
+	 * the same atoms.
 	 *
-	 * @param molecule The function that produces the state.
+	 * @param callback The function that produces the state.
 	 * @param options Optional configuration.
 	 * @returns A new read-only atom.
 	 */
-	function computed<State>(molecule: Molecule<State>, options?: AtomOptions<State>): Molecule<State>;
+	function computed<State>(callback: Selector<State>, options?: AtomOptions<State>): Selector<State>;
 
 	/**
-	 * Subscribes to changes in the given atom or molecule. The callback is
+	 * Subscribes to changes in the given atom or selector. The callback is
 	 * called with the current state and the previous state immediately after a
 	 * change occurs.
 	 *
-	 * @param molecule The atom or molecule to subscribe to.
-	 * @param callback The function to call when the state changes.
+	 * @param callback The atom or selector to subscribe to.
+	 * @param listener The function to call when the state changes.
 	 * @returns A function that unsubscribes the callback.
 	 */
-	function subscribe<State>(molecule: Molecule<State>, callback: (state: State, prev: State) => void): Cleanup;
+	function subscribe<State>(callback: Selector<State>, listener: (state: State, prev: State) => void): Cleanup;
 
 	/**
 	 * Runs the given callback immediately and whenever any atom it depends on
@@ -98,11 +98,11 @@ declare namespace Charm {
 	 * Returns the result of the function without subscribing to changes. If a
 	 * non-function value is provided, it is returned as is.
 	 *
-	 * @param molecule The atom or molecule to get the state of.
-	 * @param args Arguments to pass to the molecule.
+	 * @param callback The atom or selector to get the state of.
+	 * @param args Arguments to pass to the function.
 	 * @returns The current state.
 	 */
-	function peek<State, Args extends unknown[]>(molecule: State | ((...args: Args) => State), ...args: Args): State;
+	function peek<State, Args extends unknown[]>(callback: State | ((...args: Args) => State), ...args: Args): State;
 
 	/**
 	 * Returns whether the given value is an atom.
@@ -124,13 +124,14 @@ declare namespace Charm {
 	 * Captures all atoms that are read during the function call and returns them
 	 * along with the result of the function. Useful for tracking dependencies.
 	 *
-	 * @param molecule The function to run.
+	 * @param callback The function to run.
 	 * @returns A tuple containing the captured atoms and the result of the function.
 	 */
-	function capture<State>(molecule: Molecule<State>): LuaTuple<[dependencies: Set<Atom<unknown>>, state: State]>;
+	function capture<State>(callback: Selector<State>): LuaTuple<[dependencies: Set<Atom<unknown>>, state: State]>;
 
 	/**
 	 * Notifies all subscribers of the given atom that the state has changed.
+	 * Mainly for running effects, since subscriptions check for equality.
 	 *
 	 * @param atom The atom to notify.
 	 */
@@ -141,17 +142,17 @@ declare namespace Charm {
 	 * cleans up the instance when the item is removed. Returns a cleanup function
 	 * that unsubscribes all instances.
 	 *
-	 * @param molecule The atom or molecule to observe.
+	 * @param callback The atom or selector to observe.
 	 * @param factory The function that tracks the lifecycle of each item.
 	 * @returns A function that unsubscribes all instances.
 	 */
 	function observe<Item>(
-		molecule: Molecule<readonly Item[]>,
+		callback: Selector<readonly Item[]>,
 		factory: (item: Item, index: number) => Cleanup | void,
 	): Cleanup;
 
 	function observe<Key, Item>(
-		molecule: Molecule<AnyMap<Key, Item>>,
+		callback: Selector<AnyMap<Key, Item>>,
 		factory: (item: Item, key: Key) => Cleanup | void,
 	): Cleanup;
 
@@ -161,22 +162,22 @@ declare namespace Charm {
 	 * When the atom changes, the `mapper` is called for each entry in the state
 	 * to compute the new state.
 	 *
-	 * @param molecule The atom or molecule to map.
+	 * @param callback The atom or selector to map.
 	 * @param mapper The function that maps each entry.
 	 * @returns A new atom with the mapped state.
 	 */
 	function mapped<V0, K1, V1>(
-		molecule: Molecule<readonly V0[]>,
+		callback: Selector<readonly V0[]>,
 		mapper: (value: V0, index: number) => LuaTuple<[value: V1 | undefined, key: K1]>,
-	): Molecule<ReadonlyMap<K1, V1>>;
+	): Selector<ReadonlyMap<K1, V1>>;
 
 	function mapped<V0, V1>(
-		molecule: Molecule<readonly V0[]>,
+		callback: Selector<readonly V0[]>,
 		mapper: (value: V0, index: number) => V1,
-	): Molecule<readonly V1[]>;
+	): Selector<readonly V1[]>;
 
 	function mapped<K0, V0, K1 = K0, V1 = V0>(
-		molecule: Molecule<AnyMap<K0, V0>>,
+		callback: Selector<AnyMap<K0, V0>>,
 		mapper: (value: V0, key: K0) => LuaTuple<[value: V1 | undefined, key: K1]> | V1,
-	): Molecule<ReadonlyMap<K1, V1>>;
+	): Selector<ReadonlyMap<K1, V1>>;
 }

--- a/src/charm/src/init.luau
+++ b/src/charm/src/init.luau
@@ -8,8 +8,8 @@ local subscribe = require(script.subscribe)
 local types = require(script.types)
 
 export type Atom<State> = types.Atom<State>
-export type Molecule<State> = types.Selector<State>
 export type Selector<State> = types.Selector<State>
+export type Molecule<State> = types.Selector<State>
 export type SyncPayload = types.SyncPayload
 
 return {

--- a/src/charm/src/init.luau
+++ b/src/charm/src/init.luau
@@ -8,7 +8,8 @@ local subscribe = require(script.subscribe)
 local types = require(script.types)
 
 export type Atom<State> = types.Atom<State>
-export type Molecule<State> = types.Molecule<State>
+export type Molecule<State> = types.Selector<State>
+export type Selector<State> = types.Selector<State>
 export type SyncPayload = types.SyncPayload
 
 return {

--- a/src/charm/src/mapped.luau
+++ b/src/charm/src/mapped.luau
@@ -3,12 +3,12 @@ local effect = require(script.Parent.effect)
 local store = require(script.Parent.store)
 local types = require(script.Parent.types)
 type Atom<T> = types.Atom<T>
-type Molecule<T> = types.Molecule<T>
+type Selector<T> = types.Selector<T>
 
 type Map =
-	(<K0, V0, K1, V1>(fn: Molecule<{ [K0]: V0 }>, mapper: (V0, K0) -> (V1?, K1)) -> Molecule<{ [K1]: V1 }>)
-	& (<K0, V0, V1>(fn: Molecule<{ [K0]: V0 }>, mapper: (V0, K0) -> V1?) -> Molecule<{ [K0]: V1 }>)
-	& (<K0, V0, K1, V1>(fn: Molecule<{ [K0]: V0 }>, mapper: (V0, K0) -> (V1?, K1?)) -> Molecule<{ [K1]: V1 }>)
+	(<K0, V0, K1, V1>(fn: Selector<{ [K0]: V0 }>, mapper: (V0, K0) -> (V1?, K1)) -> Selector<{ [K1]: V1 }>)
+	& (<K0, V0, V1>(fn: Selector<{ [K0]: V0 }>, mapper: (V0, K0) -> V1?) -> Selector<{ [K0]: V1 }>)
+	& (<K0, V0, K1, V1>(fn: Selector<{ [K0]: V0 }>, mapper: (V0, K0) -> (V1?, K1?)) -> Selector<{ [K1]: V1 }>)
 
 --[=[
 	Maps each entry in the atom's state to a new key-value pair. If the `mapper`
@@ -16,11 +16,11 @@ type Map =
 	When the atom changes, the `mapper` is called for each entry in the state
 	to compute the new state.
 	
-	@param molecule The atom or molecule to map.
+	@param callback The atom or selector to map.
 	@param mapper The function that maps each entry.
 	@return A new atom with the mapped state.
 ]=]
-local function mapped<K0, V0, K1, V1>(molecule: Molecule<{ [K0]: V0 }>, mapper: (V0, K0) -> (V1?, K1?)): Molecule<{ [K1]: V1 }>
+local function mapped<K0, V0, K1, V1>(callback: Selector<{ [K0]: V0 }>, mapper: (V0, K0) -> (V1?, K1?)): Selector<{ [K1]: V1 }>
 	local mappedAtom = atom({})
 	local mappedAtomRef = setmetatable({ current = mappedAtom }, { __mode = "v" })
 	local prevMappedItems: { [K1]: V1 } = {}
@@ -31,7 +31,7 @@ local function mapped<K0, V0, K1, V1>(molecule: Molecule<{ [K0]: V0 }>, mapper: 
 			return unsubscribe()
 		end
 
-		local items = molecule()
+		local items = callback()
 		local mappedItems = table.clone(store.peek(mappedAtomRef.current))
 		local mappedKeys = {}
 

--- a/src/charm/src/observe.luau
+++ b/src/charm/src/observe.luau
@@ -9,15 +9,15 @@ local function noop() end
 	cleans up the instance when the item is removed. Returns a cleanup function
 	that unsubscribes all instances.
 	
-	@param molecule The atom or molecule to observe.
+	@param callback The atom or selector to observe.
 	@param factory The function that tracks the lifecycle of each item.
 	@return A function that unsubscribes all instances.
 ]=]
-local function observe<K, V>(molecule: Selector<{ [K]: V }>, factory: (value: V, key: K) -> (() -> ())?): () -> ()
+local function observe<K, V>(callback: Selector<{ [K]: V }>, factory: (value: V, key: K) -> (() -> ())?): () -> ()
 	local connections: { [K]: () -> () } = {}
 
 	local unsubscribe = effect(function()
-		local state = molecule()
+		local state = callback()
 
 		for key, disconnect in next, connections do
 			if state[key] == nil then

--- a/src/charm/src/observe.luau
+++ b/src/charm/src/observe.luau
@@ -1,6 +1,6 @@
 local effect = require(script.Parent.effect)
 local types = require(script.Parent.types)
-type Molecule<T> = types.Molecule<T>
+type Selector<T> = types.Selector<T>
 
 local function noop() end
 
@@ -13,7 +13,7 @@ local function noop() end
 	@param factory The function that tracks the lifecycle of each item.
 	@return A function that unsubscribes all instances.
 ]=]
-local function observe<K, V>(molecule: Molecule<{ [K]: V }>, factory: (value: V, key: K) -> (() -> ())?): () -> ()
+local function observe<K, V>(molecule: Selector<{ [K]: V }>, factory: (value: V, key: K) -> (() -> ())?): () -> ()
 	local connections: { [K]: () -> () } = {}
 
 	local unsubscribe = effect(function()

--- a/src/charm/src/store.luau
+++ b/src/charm/src/store.luau
@@ -100,8 +100,8 @@ end
 	Returns the result of the function without subscribing to changes. If a
 	non-function value is provided, it is returned as is.
 	
-	@param molecule The atom or molecule to get the state of.
-	@param args Arguments to pass to the molecule.
+	@param callback The atom or selector to get the state of.
+	@param args Arguments to pass to the function.
 	@return The current state.
 ]=]
 local function peek<T, U...>(callback: ((U...) -> T) | T, ...: U...): T
@@ -128,12 +128,12 @@ end
 	Captures all atoms that are read during the function call and returns them
 	along with the result of the function. Useful for tracking dependencies.
 	
-	@param molecule The function to run.
+	@param callback The function to run.
 	@return A tuple containing the captured atoms and the result of the function.
 ]=]
-local function capture<T>(molecule: () -> T): (Set<Atom<any>>, T)
-	if listeners[molecule] then
-		return { [molecule] = true }, peek(molecule)
+local function capture<T>(callback: () -> T): (Set<Atom<any>>, T)
+	if listeners[callback] then
+		return { [callback] = true }, peek(callback)
 	end
 
 	local dependencies: Set<Atom<any>> = {}
@@ -141,7 +141,7 @@ local function capture<T>(molecule: () -> T): (Set<Atom<any>>, T)
 	capturing.index += 1
 	capturing.stack[capturing.index] = dependencies
 
-	local result = try(molecule, function()
+	local result = try(callback, function()
 		capturing.stack[capturing.index] = nil
 		capturing.index -= 1
 	end)

--- a/src/charm/src/subscribe.luau
+++ b/src/charm/src/subscribe.luau
@@ -3,39 +3,39 @@ local types = require(script.Parent.types)
 type Selector<T> = types.Selector<T>
 
 --[=[
-	Subscribes to changes in the given atom or molecule. The callback is
+	Subscribes to changes in the given atom or selector. The callback is
 	called with the current state and the previous state immediately after a
 	change occurs.
 	
-	@param molecule The atom or molecule to subscribe to.
-	@param callback The function to call when the state changes.
+	@param callback The atom or selector to subscribe to.
+	@param listener The function to call when the state changes.
 	@return A function that unsubscribes the callback.
 ]=]
-local function subscribe<T>(molecule: Selector<T>, callback: (state: T, prev: T) -> ()): () -> ()
-	local dependencies, state = store.capture(molecule)
+local function subscribe<T>(callback: Selector<T>, listener: (state: T, prev: T) -> ()): () -> ()
+	local dependencies, state = store.capture(callback)
 	local disconnected = false
 
-	local function listener()
+	local function handler()
 		local prevState = state
 
-		store.disconnect(dependencies, listener)
-		dependencies, state = store.capture(molecule)
+		store.disconnect(dependencies, handler)
+		dependencies, state = store.capture(callback)
 
 		if not disconnected then
-			store.connect(dependencies, listener)
+			store.connect(dependencies, handler)
 		end
 
 		if state ~= prevState then
-			callback(state, prevState)
+			listener(state, prevState)
 		end
 	end
 
-	store.connect(dependencies, listener)
+	store.connect(dependencies, handler)
 
 	return function()
 		if not disconnected then
 			disconnected = true
-			store.disconnect(dependencies, listener)
+			store.disconnect(dependencies, handler)
 		end
 	end
 end

--- a/src/charm/src/subscribe.luau
+++ b/src/charm/src/subscribe.luau
@@ -1,6 +1,6 @@
 local store = require(script.Parent.store)
 local types = require(script.Parent.types)
-type Molecule<T> = types.Molecule<T>
+type Selector<T> = types.Selector<T>
 
 --[=[
 	Subscribes to changes in the given atom or molecule. The callback is
@@ -11,7 +11,7 @@ type Molecule<T> = types.Molecule<T>
 	@param callback The function to call when the state changes.
 	@return A function that unsubscribes the callback.
 ]=]
-local function subscribe<T>(molecule: Molecule<T>, callback: (state: T, prev: T) -> ()): () -> ()
+local function subscribe<T>(molecule: Selector<T>, callback: (state: T, prev: T) -> ()): () -> ()
 	local dependencies, state = store.capture(molecule)
 	local disconnected = false
 

--- a/src/charm/src/types.luau
+++ b/src/charm/src/types.luau
@@ -9,7 +9,7 @@ export type WeakMap<K, V> = typeof(setmetatable({} :: { [K]: V }, { __mode = "k"
 	@param state The next state or a function that produces the next state.
 	@return The current state, if no arguments are provided.
 ]=]
-export type Atom<T> = (() -> T) & (state: T | (T) -> T) -> T
+export type Atom<T> = (state: (T | (T) -> T)?) -> T
 
 --[=[
 	A function that depends on one or more atoms and produces a state. Can be
@@ -18,7 +18,7 @@ export type Atom<T> = (() -> T) & (state: T | (T) -> T) -> T
 	@template State The type of the state.
 	@return The current state.
 ]=]
-export type Molecule<T> = () -> T
+export type Selector<T> = () -> T
 
 --[=[
 	Optional configuration for creating an atom.

--- a/src/react/src/index.d.ts
+++ b/src/react/src/index.d.ts
@@ -1,15 +1,15 @@
-import { Molecule } from "@rbxts/charm";
+import { Selector } from "@rbxts/charm";
 
 /**
- * A hook that subscribes to changes in the given atom or molecule. The
+ * A hook that subscribes to changes in the given atom or selector. The
  * component is re-rendered whenever the state changes.
  *
  * If the `dependencies` array is provided, the subscription to the atom or
- * molecule is re-created whenever the dependencies change. Otherwise, the
+ * selector is re-created whenever the dependencies change. Otherwise, the
  * subscription is created once when the component is mounted.
  *
- * @param molecule The atom or molecule to subscribe to.
+ * @param callback The atom or selector to subscribe to.
  * @param dependencies An array of values that the subscription depends on.
  * @returns The current state.
  */
-export function useAtom<State>(molecule: Molecule<State>, dependencies?: unknown[]): State;
+export function useAtom<State>(callback: Selector<State>, dependencies?: unknown[]): State;

--- a/src/react/src/init.luau
+++ b/src/react/src/init.luau
@@ -4,23 +4,23 @@ local React = if script.Parent:FindFirstChild("react")
 	else require(script.Parent.React)
 
 --[=[
-	A hook that subscribes to changes in the given atom or molecule. The
+	A hook that subscribes to changes in the given atom or selector. The
 	component is re-rendered whenever the state changes.
 	
 	If the `dependencies` array is provided, the subscription to the atom or
-	molecule is re-created whenever the dependencies change. Otherwise, the
+	selector is re-created whenever the dependencies change. Otherwise, the
 	subscription is created once when the component is mounted.
 	
-	@param molecule The atom or molecule to subscribe to.
+	@param callback The atom or selector to subscribe to.
 	@param dependencies An array of values that the subscription depends on.
 	@return The current state.
 ]=]
-local function useAtom<State>(molecule: Charm.Molecule<State>, dependencies: { any }?): State
-	local state, setState = React.useState(molecule)
+local function useAtom<State>(callback: Charm.Selector<State>, dependencies: { any }?): State
+	local state, setState = React.useState(callback)
 
 	React.useEffect(function()
-		setState(molecule())
-		return Charm.subscribe(molecule, setState)
+		setState(callback())
+		return Charm.subscribe(callback, setState)
 	end, dependencies or {})
 
 	return state

--- a/src/vide/src/index.d.ts
+++ b/src/vide/src/index.d.ts
@@ -1,9 +1,9 @@
-import { Molecule } from "@rbxts/charm";
+import { Selector } from "@rbxts/charm";
 
 /**
  * Subscribes to the state of an atom and returns a Vide source.
  *
- * @param molecule The atom or molecule to subscribe to.
+ * @param callback The atom or selector to subscribe to.
  * @returns The reactive source.
  */
-export function useAtom<T>(atom: Molecule<T>): () => T;
+export function useAtom<T>(callback: Selector<T>): () => T;

--- a/src/vide/src/init.luau
+++ b/src/vide/src/init.luau
@@ -6,12 +6,12 @@ local Vide = if script.Parent:FindFirstChild("vide")
 --[=[
 	Subscribes to the state of an atom and returns a Vide source.
 	
-	@param molecule The atom or molecule to subscribe to.
+	@param callback The atom or selector to subscribe to.
 	@return The reactive source.
 ]=]
-local function useAtom<State>(molecule: () -> State): State
-	local state = Vide.source(molecule())
-	local unsubscribe = Charm.subscribe(molecule, function(value)
+local function useAtom<State>(callback: () -> State): State
+	local state = Vide.source(callback())
+	local unsubscribe = Charm.subscribe(callback, function(value)
 		task.spawn(state, value)
 	end)
 

--- a/tests/react/useAtom.spec.luau
+++ b/tests/react/useAtom.spec.luau
@@ -17,7 +17,7 @@ return function()
 		expect(hook.result).to.equal(1)
 	end)
 
-	it("accepts a molecule", function()
+	it("accepts a selector", function()
 		local state = atom(0)
 		local hook = renderHook(function()
 			return useAtom(function()

--- a/tests/vide/useAtom.spec.luau
+++ b/tests/vide/useAtom.spec.luau
@@ -20,7 +20,7 @@ return function()
 		cleanup()
 	end)
 
-	it("accepts a molecule", function()
+	it("accepts a selector", function()
 		local state = atom(0)
 		local source
 		local cleanup = root(function()


### PR DESCRIPTION
Rewrite the docs to improve legibility and reduce abstract terminology. Replace all references to "molecules" with selector functions.