### PR TITLE
feat(sync): add `flatten()` function

### DIFF
--- a/packages/charm-sync/src/flatten.luau
+++ b/packages/charm-sync/src/flatten.luau
@@ -1,0 +1,28 @@
+local types = require(script.Parent.types)
+type AtomMap = types.AtomMap
+
+type NestedAtomMap = {
+	[string]: NestedAtomMap | () -> (),
+}
+
+local function flatten(atoms: NestedAtomMap): AtomMap
+	local result: AtomMap = {}
+
+	local function visit(node: NestedAtomMap, path: string)
+		for key, value in node do
+			local location = if path == "" then key else path .. "/" .. key
+
+			if type(value) == "table" then
+				visit(value, location)
+			else
+				result[location] = value
+			end
+		end
+	end
+
+	visit(atoms, "")
+
+	return result
+end
+
+return flatten

--- a/packages/charm-sync/src/init.luau
+++ b/packages/charm-sync/src/init.luau
@@ -1,4 +1,5 @@
 local client = require(script.client)
+local flatten = require(script.flatten)
 local patch = require(script.patch)
 local server = require(script.server)
 local types = require(script.types)
@@ -12,5 +13,6 @@ export type SyncPayload = types.SyncPayload
 return {
 	client = client,
 	server = server,
+	flatten = flatten,
 	isNone = patch.isNone,
 }

--- a/tests/charm-sync/flatten.spec.luau
+++ b/tests/charm-sync/flatten.spec.luau
@@ -1,0 +1,24 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Charm = require(ReplicatedStorage.DevPackages.Charm)
+local atom = Charm.atom
+local CharmSync = require(ReplicatedStorage.DevPackages.CharmSync)
+local flatten = CharmSync.flatten
+
+return function()
+	it("flattens atoms", function()
+		local input = {
+			a = atom(0),
+			b = { c = atom(0) },
+			d = { e = { f = atom(0) } },
+		}
+		local result = flatten(input)
+
+		expect(result.a).to.equal(input.a)
+		expect(result["b/c"]).to.equal(input.b.c)
+		expect(result["d/e/f"]).to.equal(input.d.e.f)
+
+		expect(result.b).to.never.be.ok()
+		expect(result.d).to.never.be.ok()
+	end)
+end


### PR DESCRIPTION
Adds the `flatten(atoms)` function for flattening a nested map of atoms into a valid `AtomMap` type.