### PR TITLE
fix(charm-sync): change `SyncPatch` array type to represent actual data

### DIFF
--- a/packages/charm-sync/src/index.d.ts
+++ b/packages/charm-sync/src/index.d.ts
@@ -118,7 +118,7 @@ declare namespace CharmSync {
 				: State extends Set<infer T> | ReadonlySet<infer T>
 					? ReadonlyMap<T, true | None>
 					: State extends readonly (infer T)[]
-						? readonly (SyncPatch<T> | None | undefined)[]
+						? readonly (SyncPatch<T> | None | undefined)[] | ReadonlyMap<string, None>
 						: State extends DataType
 							? State
 							: State extends object


### PR DESCRIPTION
`StatePatch` type does not represent actual possible data. When charm stringifies sparse arrays, it becomes a `ReadonlyMap<string, None>`. This is very important because Flamework's type guards fails on this, and rejects the remote event.