### PR TITLE
Optimize computed's anti-recursion device

### DIFF
--- a/packages/charm/src/computed.luau
+++ b/packages/charm/src/computed.luau
@@ -18,13 +18,18 @@ local function computed<T>(callback: Selector<T>, options: AtomOptions<T>?): Sel
 	local computedAtom = atom(state, options)
 	local computedRef = setmetatable({ current = computedAtom }, { __mode = "v" })
 
+	local pauseListening = false
 	local function listener()
+		if pauseListening then
+			return
+		end
+
 		local computedAtom = computedRef.current
 
 		if computedAtom then
-			store.disconnect(dependencies, listener)
+			pauseListening = true
 			dependencies, state = store.capture(callback)
-			store.connect(dependencies, listener, computedAtom)
+			pauseListening = false
 			computedAtom(state)
 		end
 	end


### PR DESCRIPTION
Speeds up a benchmark I had connecting hundreds of these 4.3x.