### PR TITLE
Fix O2 detection probe

### DIFF
--- a/packages/charm/src/init.luau
+++ b/packages/charm/src/init.luau
@@ -69,7 +69,7 @@ local batchDepth = 0
 local activeSub: ReactiveNode?
 
 local function isO2(): boolean
-	return debug.info(1, "n") ~= "isO2"
+	return debug.info(1, "f") ~= isO2
 end
 
 local flags = {


### PR DESCRIPTION
Current O2 probe isn't working for me, so strict mode is disabled in studio.

Luau O2 inlines the function:
```text
-- remark: inlining succeeded (cost 8, profit 1.37x, depth 0)
print("isO2", isO2())
```

The generated bytecode then runs the body in the caller frame:
```text
GETIMPORT R4 [debug.info]
LOADN R5 1
LOADK R6 ['n']
CALL R4 2 1
JUMPXEQKS R4 ['isO2']
```

So `debug.info(1, "n")` is no longer checking the `isO2` frame. It is checking the frame the function was inlined into. That frame has no debug name, so the probe returns `true` because `"" ~= "isO2"`.

This replacement checks the current function object instead of the current function name:
```luau
local function isO2(): boolean
	return debug.info(1, "f") ~= isO2
end
```

When the function is not inlined, `debug.info(1, "f")` returns the `isO2` closure, so the probe returns `false`.

When the function is inlined, there is no `isO2` frame anymore, so `debug.info(1, "f")` returns the caller closure, and the probe returns `true`.

Local Luau results:
```text
O0: isO2 false, strict true, frozen true
O1: isO2 false, strict true, frozen true
O2: isO2 true,  strict false, frozen false
```

Compiler still confirms the replacement probe is inlined at O2:
```text
strict = not isO2()
-- remark: inlining succeeded (cost 8, profit 1.37x, depth 0)

frozen = not isO2()
-- remark: inlining succeeded (cost 8, profit 1.37x, depth 0)
```

